### PR TITLE
Follow prince download redirects

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-PRINCE_VERSION="10r5"
+PRINCE_VERSION="11.1"
+if [ -f $3/PRINCE_VERSION ]; then
+  PRINCE_VERSION="$(cat $3/PRINCE_VERSION)"
+fi
+
 echo "-----> Installing PrinceXML $PRINCE_VERSION"
 [ -d .downloads ] || mkdir .downloads
 (cd .downloads; [ -d "prince-$PRINCE_VERSION-linux-amd64-static" ] ||

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ fi
 echo "-----> Installing PrinceXML $PRINCE_VERSION"
 [ -d .downloads ] || mkdir .downloads
 (cd .downloads; [ -d "prince-$PRINCE_VERSION-linux-amd64-static" ] ||
-  curl -s http://www.princexml.com/download/prince-$PRINCE_VERSION-linux-generic-x86_64.tar.gz | tar xzf -)
+  curl -sL http://www.princexml.com/download/prince-$PRINCE_VERSION-linux-generic-x86_64.tar.gz | tar xzf -)
 
 if [ -f $3/PRINCE_LICENSE ]; then
   echo "       Configuring license file"


### PR DESCRIPTION
Prince XML changed the URL for releases and previous solution didn't follow redirects:
```
$ curl -s http://www.princexml.com/download/prince-$PRINCE_VERSION-linux-generic-x86_64.tar.gz
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://www.princexml.com/download/prince-11.1-linux-generic-x86_64.tar.gz">here</a>.</p>
<hr>
<address>Apache/2.2.22 (Ubuntu) Server at www.princexml.com Port 80</address>
</body></html>
```